### PR TITLE
Update Account.php

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -93,10 +93,7 @@ class Account extends ComponentBase
         if ($loginAttribute == UserSettings::LOGIN_USERNAME)
             $rules['login'] = 'required|between:2,64';
         else
-            $rules['email'] = 'required|email|between:2,64';
-
-        if (!in_array('login', $data))
-            $data['login'] = post('username', post('email'));
+            $rules['login'] = 'required|email|between:2,64';
 
         $validation = Validator::make($data, $rules);
         if ($validation->fails())


### PR DESCRIPTION
Sign In form only has 'login' and 'password' fields, no 'username' or 'email' fields exist.  Took out lines that want those form field values and fixed validation rule to work with either 'username' or 'email' UserSettings::LOGIN_\* value.

Can now login again regardless of the setting on the backend.
