### PR TITLE
Fix bug in fillable array

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -51,8 +51,8 @@ class User extends UserBase
         'street_addr',
         'city',
         'zip',
-        'country',
-        'state'
+        'country_id',
+        'state_id'
     ];
 
     /**


### PR DESCRIPTION
This bug prevented the country_id and state_id fields from being
mass-assignable when updating a user.
