### PR TITLE
Fix an activation error issue

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -197,7 +197,7 @@ class Account extends ComponentBase
             if (!strlen(trim($userId)) || !($user = Auth::findUserById($userId)))
                 throw new ApplicationException(trans('rainlab.user::lang.account.invalid_user'));
 
-            if (!$user->attemptActivation($code))
+            if ($user->attemptActivation($code) === false)
                 throw new ValidationException(['code' => trans('rainlab.user::lang.account.invalid_activation_code')]);
 
             Flash::success(trans('rainlab.user::lang.account.success_activation'));
@@ -282,6 +282,7 @@ class Account extends ComponentBase
     protected function sendActivationEmail($user)
     {
         $code = implode('!', [$user->id, $user->getActivationCode()]);
+
         $link = $this->currentPageUrl([
             $this->property('paramCode') => $code
         ]);


### PR DESCRIPTION
The activation was always flashing "Invalid activation code supplied" when user clicked the activation link in the activation email. (I've seen that even on the october official website this bug occurs)

This is because the Core User::attemptActivation() method does never
return true even in case of success but false in error and null else.

**The best solution should be to change the core in order to return true in case of successful activation but this is a workaround that will work even if the core function is updated accordingly**