### PR TITLE
Runs email validation at first, because we always need email, even if username is empty

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -16,8 +16,8 @@ class User extends UserBase
      * Validation rules
      */
     public $rules = [
-        'username' => 'required|between:2,64|unique:users',
         'email' => 'required|between:3,64|email|unique:users',
+        'username' => 'required|between:2,64|unique:users',
         'password' => 'required:create|between:4,64|confirmed',
         'password_confirmation' => 'required_with:password|between:4,64'
     ];


### PR DESCRIPTION
When the username is not used, the email is substituted. But when email is empty, it throws "The username field is required." because it uses 'username' attribute validation rule.

https://github.com/rainlab/user-plugin/blob/master/models/User.php#L91

Solution is fire email rule at first place.
