### PR TITLE
Require permission on settings page too

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -84,7 +84,8 @@ class Plugin extends PluginBase
                 'category'    => 'rainlab.user::lang.settings.users',
                 'icon'        => 'icon-cog',
                 'class'       => 'RainLab\User\Models\Settings',
-                'order'       => 500
+                'order'       => 500,
+                'permissions' => ['rainlab.users.*'],
             ],
             'location' => [
                 'label'       => 'rainlab.user::lang.locations.menu_label',
@@ -92,7 +93,8 @@ class Plugin extends PluginBase
                 'category'    => 'rainlab.user::lang.settings.users',
                 'icon'        => 'icon-globe',
                 'url'         => Backend::url('rainlab/user/locations'),
-                'order'       => 500
+                'order'       => 500,
+                'permissions' => ['rainlab.users.*'],
             ]
         ];
     }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -30,3 +30,5 @@
 1.0.15:
     - Adds last name column to users table (surname).
     - users_add_surname.php
+1.0.16:
+    - Require Permission 'permissions' => ['rainlab.users.*'] for Settings-Page too


### PR DESCRIPTION
If a Backend-User is not allowed to "Manage Users" he should also not be able to access the Settings part of the Userplugin!