### PR TITLE
Fix onUpdate account for Build 273

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -250,8 +250,9 @@ class Account extends ComponentBase
     {
         if (!$user = $this->user())
             return;
-
-        $user->save(post());
+    
+        $user->fill(post());
+        $user->save();
 
         /*
          * Password has changed, reauthenticate the user


### PR DESCRIPTION
After update to [Build 273](https://octobercms.com/forum/post/update-to-modelsave-method) the account profile doesn't save data.