### PR TITLE
Add permissions for user plugin's settings

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -55,7 +55,8 @@ class Plugin extends PluginBase
     {
         return [
             'rainlab.users.access_users' => ['tab' => 'rainlab.user::lang.plugin.tab', 'label' => 'rainlab.user::lang.plugin.access_users'],
-            'rainlab.users.access_groups' => ['tab' => 'rainlab.user::lang.plugin.tab', 'label' => 'rainlab.user::lang.plugin.access_groups']
+            'rainlab.users.access_groups' => ['tab' => 'rainlab.user::lang.plugin.tab', 'label' => 'rainlab.user::lang.plugin.access_groups'],
+			'rainlab.users.access_settings' => ['tab' => 'rainlab.user::lang.plugin.tab', 'label' => 'rainlab.user::lang.plugin.access_settings']
         ];
     }
 
@@ -82,7 +83,7 @@ class Plugin extends PluginBase
                 'icon'        => 'icon-cog',
                 'class'       => 'RainLab\User\Models\Settings',
                 'order'       => 500,
-                'permissions' => ['rainlab.users.*']
+                'permissions' => ['rainlab.users.settings']
             ]
         ];
     }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -6,7 +6,8 @@ return [
         'description' => 'Front-end user management.',
         'tab' => 'Users',
         'access_users' => 'Manage Users',
-        'access_groups' => 'Manage User Groups'
+        'access_groups' => 'Manage User Groups',
+        'access_settings' => 'Manage User Settings'
     ],
     'users' => [
         'menu_label' => 'Users',

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -6,7 +6,8 @@ return [
         'description' => 'Gestion des utilisateurs Front-End.',
         'tab' => 'Utilisateur',
         'access_users' => 'Gérer les utilisateurs',
-        'access_groups' => 'Gérer les groupes'
+        'access_groups' => 'Gérer les groupes',
+        'access_settings' => 'Gérer les Settings'
     ],
     'users' => [
         'menu_label' => 'Utilisateurs',


### PR DESCRIPTION
Ability to hide the settings menu items for certain groups of admins.

We needed this ability in our project and found no way of hiding the plugin setting menu while keeping the top menu user item.

So now settings permissions are independant of the user management menu permissions.