### PR TITLE
Remove group button if already defined in sideMenu

### DIFF
--- a/controllers/usergroups/_list_toolbar.htm
+++ b/controllers/usergroups/_list_toolbar.htm
@@ -1,9 +1,11 @@
 <div data-control="toolbar">
+    <?php if (!array_key_exists('usergroups', BackendMenu::listSideMenuItems())) { ?>
     <a
         href="<?= Backend::url('rainlab/user/users') ?>"
         class="btn btn-default oc-icon-chevron-left">
         <?= e(trans('rainlab.user::lang.groups.return_to_users')) ?>
     </a>
+    <?php } ?>
     <a
         href="<?= Backend::url('rainlab/user/usergroups/create') ?>"
         class="btn btn-primary oc-icon-plus">

--- a/controllers/users/_list_toolbar.htm
+++ b/controllers/users/_list_toolbar.htm
@@ -5,9 +5,11 @@
         <?= e(trans('rainlab.user::lang.users.new_user')) ?>
     </a>
 
+    <?php if (!array_key_exists('usergroups', BackendMenu::listSideMenuItems())) { ?>
     <a href="<?= Backend::url('rainlab/user/usergroups') ?>" class="btn btn-default oc-icon-group">
         <?= e(trans('rainlab.user::lang.groups.all_groups')) ?>
     </a>
+    <?php } ?>
 
     <div class="btn-group dropdown dropdown-fixed" data-control="bulk-actions">
         <button


### PR DESCRIPTION
Subject: Remove "Group button" and "Back to users" button if Groups are already defined in sideMenu.

Reason: If I register sideMenu, buttons are then redundant. I using Users left sideMenu on each project, because then it has the same layout as Blog and other plugins. Target is to have united backend layout.

![screenshot](https://cloud.githubusercontent.com/assets/374917/13879197/75303cd8-ed16-11e5-8336-ac3f03309dbe.png)