### PR TITLE
Add rainlab.user.logout event

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ This plugin will fire some global events that can be useful for interacting with
 
 - **rainlab.user.beforeAuthenticate**: Before the user is attempting to authenticate using the Account component.
 - **rainlab.user.login**: The user has successfully signed in.
+- **rainlab.user.logout**: The user has successfully signed out.
 - **rainlab.user.deactivate**: The user has opted-out of the site by deactivating their account. This should be used to disable any content the user may want removed.
 - **rainlab.user.reactivate**: The user has reactivated their own account by signing back in. This should revive the users content on the site.
 

--- a/components/Session.php
+++ b/components/Session.php
@@ -82,7 +82,14 @@ class Session extends ComponentBase
      */
     public function onLogout()
     {
+        $user = Auth::getUser();
+
         Auth::logout();
+
+        if ($user) {
+            Event::fire('rainlab.user.logout', [$user]);
+        }
+
         $url = post('redirect', Request::fullUrl());
         Flash::success(Lang::get('rainlab.user::lang.session.logout'));
 


### PR DESCRIPTION
Added rainlab.user.logout event for custom managing while user logged out. 
Can be useful for deleting session data, cache etc.