### PR TITLE
Fix Inverted name/surname french translation + externalize online status strings

### DIFF
--- a/controllers/users/_preview_scoreboard.htm
+++ b/controllers/users/_preview_scoreboard.htm
@@ -21,7 +21,7 @@
         <h4><?= e(trans('rainlab.user::lang.user.last_seen')) ?></h4>
         <p><?= $formModel->last_seen->diffForHumans() ?></p>
         <p class="description">
-            <?= $formModel->isOnline() ? 'Online now' : 'Currently offline' ?>
+            <?= $formModel->isOnline() ? e(trans('rainlab.user::lang.user.is_online')) : e(trans('rainlab.user::lang.user.is_offline')) ?>
         </p>
     </div>
 <?php endif ?>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -90,6 +90,8 @@ return [
         'created_at' => 'Registered',
         'last_seen' => 'Last seen',
         'joined' => 'Joined',
+        'is_online' => 'Online now',
+        'is_offline' => 'Currently offline',
         'create_password' => 'Create Password',
         'create_password_comment' => 'Enter a new password used for signing in.',
         'reset_password' => 'Reset Password',

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -84,9 +84,9 @@ return [
     'user' => [
         'label' => 'Utilisateur',
         'id' => 'ID',
-        'username' => 'Pseudonyme de l’utilisateur',
-        'name' => 'Nom',
-        'surname' => 'Prénom',
+        'username' => 'Identifiant',
+        'name' => 'Prénom',
+        'surname' => 'Nom',
         'email' => 'E-mail',
         'created_at' => 'Enregistré le',
         'last_seen' => 'Dernière connexion',

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -91,6 +91,8 @@ return [
         'created_at' => 'Enregistré le',
         'last_seen' => 'Dernière connexion',
         'joined' => 'Inscrit le',
+        'is_online' => 'Est actuellement connecté',
+        'is_offline' => 'N’est pas connecté',
         'create_password' => 'Créer un mot de passe',
         'create_password_comment' => 'Entrez un nouveau mot de passe de connexion.',
         'reset_password' => 'Réinitialiser le mot de passe',


### PR DESCRIPTION
Missed that one the other day. If I'm not wrong the logic should be : 
`name` == _first name_ == _Prénom_
`surname` == _last name_ == _Nom_

If that's the case, it requires to invert the original french translation.

Shortened the `username` field to something more common too.