### PR TITLE
Remove extraneous 'nominated'

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -161,7 +161,7 @@ return [
         'success_saved' => 'Settings successfully saved!',
         'login_first' => 'You must be logged in first!',
         'already_active' => 'Your account is already activated!',
-        'activation_email_sent' => 'An activation email has been sent to your nominated email address.',
+        'activation_email_sent' => 'An activation email has been sent to your email address.',
         'registration_disabled' => 'Registrations are currently disabled.',
         'sign_in' => 'Sign in',
         'register' => 'Register',


### PR DESCRIPTION
'your nominated email address' doesn't make any sense, it should be 'your email address' or even 'your provided email address'.