### PR TITLE
Specify where onCheckEmail should be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The User plugin displays AJAX error messages in a simple ``alert()``-box by defa
 
 ### Checking if a login name is already taken
 
-Here is a simple example of how you can quickly check if an email address / username is available in your registration forms. First create an AJAX handler to check the login name, here we are using the email address:
+Here is a simple example of how you can quickly check if an email address / username is available in your registration forms. First, inside the page code, define the following AJAX handler to check the login name, here we are using the email address:
 
     public function onCheckEmail()
     {


### PR DESCRIPTION
I guess `onCheckEmail` should be defined inside the page code, so I updated the document accordingly. Please correct me if my suggestion is wrong.