### PR TITLE
fire rainlab.user.beforeRegister

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ To disable the notification and password reset, pass the first argument as false
 This plugin will fire some global events that can be useful for interacting with other plugins.
 
 - **rainlab.user.beforeAuthenticate**: Before the user is attempting to authenticate using the Account component.
+- **rainlab.user.beforeRegister**: Before the user is registered using the Account component.
 - **rainlab.user.login**: The user has successfully signed in.
 - **rainlab.user.logout**: The user has successfully signed out.
 - **rainlab.user.deactivate**: The user has opted-out of the site by deactivating their account. This should be used to disable any content the user may want removed.

--- a/components/Account.php
+++ b/components/Account.php
@@ -181,6 +181,9 @@ class Account extends ComponentBase
                 $rules['username'] = 'required|between:2,255';
             }
 
+            //pass by reference so other extensions can add or remove validation
+            Event::fire('rainlab.user.beforeRegister', [$this, & $rules, & $data]);
+
             $validation = Validator::make($data, $rules);
             if ($validation->fails()) {
                 throw new ValidationException($validation);


### PR DESCRIPTION
Added beforeRegister in order to add custom validation logic as described herer https://github.com/rainlab/user-plugin/issues/226


In custom plugin boot method it can be used like this:
```      
Event::listen('rainlab.user.beforeRegister', function($account, &$rules, &$data) {
            $rules['web'] = 'required';
            unset($rules['email']);
        });
``` 