### PR TITLE
fix validate password confirmation

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -174,7 +174,7 @@ class Account extends ComponentBase
 
             $rules = [
                 'email'    => 'required|email|between:6,255',
-                'password' => 'required|between:4,255'
+                'password' => 'required|between:4,255|confirmed'
             ];
 
             if ($this->loginAttribute() == UserSettings::LOGIN_USERNAME) {


### PR DESCRIPTION
There was no validation that password field has to be confirmed. If there is no `password_confirmation` field on frontend than you already have code below implemented so this validation should pass.

````
if (!array_key_exists('password_confirmation', $data)) {
                $data['password_confirmation'] = post('password');
            }
```