### PR TITLE
Add group allowance to session security

### DIFF
--- a/components/Session.php
+++ b/components/Session.php
@@ -9,6 +9,7 @@ use Redirect;
 use Cms\Classes\Page;
 use Cms\Classes\ComponentBase;
 use RainLab\User\Models\UserGroup;
+
 use ValidationException;
 
 class Session extends ComponentBase

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -186,6 +186,8 @@ return [
         'all' => 'All',
         'users' => 'Users',
         'guests' => 'Guests',
+        'allowed_groups_title' => 'Allow groups',
+        'allowed_groups_description' => 'Choose allowed groups or none to allow all groups',
         'redirect_title' => 'Redirect to',
         'redirect_desc' => 'Page name to redirect if access is denied.',
         'logout' => 'You have been successfully logged out!'


### PR DESCRIPTION
Is there also a way to hide the `groupsAllowed` inspector option if `ALL` or `GUEST` is selected and only show it if `security` is set to `USER`?

Refers to issue https://github.com/rainlab/user-plugin/issues/127