### PR TITLE
Add property $relationConfig

### DIFF
--- a/controllers/UserGroups.php
+++ b/controllers/UserGroups.php
@@ -17,6 +17,7 @@ class UserGroups extends Controller
 
     public $formConfig = 'config_form.yaml';
     public $listConfig = 'config_list.yaml';
+    public $relationConfig;
 
     public $requiredPermissions = ['rainlab.users.access_groups'];
 


### PR DESCRIPTION
Allows extensions of UserGroups controller to use relations.

Like:

UserGroups::extend(function (GroupController $controller) {
    $controller->relationConfig =
                Yaml::parse(File::get('plugins/kurtjensen/profile/controllers/usergroups/config_relation.yaml'));
});