### PR TITLE
Fix #243

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -322,9 +322,9 @@ class Account extends ComponentBase
         if (!$user->checkHashValue('password', post('password'))) {
             throw new ValidationException(['password' => Lang::get('rainlab.user::lang.account.invalid_deactivation_pass')]);
         }
-
-        $user->delete();
+        
         Auth::logout();
+        $user->delete();
 
         Flash::success(post('flash', Lang::get('rainlab.user::lang.account.success_deactivation')));
 


### PR DESCRIPTION
This fixes #243 by deleting the user record after first logging them out when deactivating the user as the the logout method calls `forceSave()` on the user model which was previously deleted immediately prior to performing the logout.