### PR TITLE
Fire "rainlab.user.register" from within "Auth::register"

### DIFF
--- a/classes/AuthManager.php
+++ b/classes/AuthManager.php
@@ -39,8 +39,11 @@ class AuthManager extends RainAuthManager
         if ($guest = $this->findGuestUserByCredentials($credentials)) {
             return $this->convertGuestToUser($guest, $credentials, $activate);
         }
-
-        return parent::register($credentials, $activate);
+        
+        $user = parent::register($credentials, $activate);
+        Event::fire('rainlab.user.register', [$user, $credentials]);
+        
+        return $user;
     }
 
     //

--- a/components/Account.php
+++ b/components/Account.php
@@ -256,8 +256,6 @@ class Account extends ComponentBase
             $userActivation = UserSettings::get('activate_mode') == UserSettings::ACTIVATE_USER;
             $user = Auth::register($data, $automaticActivation);
 
-            Event::fire('rainlab.user.register', [$user, $data]);
-
             /*
              * Activation is by the user, send the email
              */


### PR DESCRIPTION
I think it's a good idea to fire `rainlab.user.register` from within `Auth::register()` instead of firing it after calling `Auth::register()` in `onRegister()`.  This is specifically useful in other plugins that use this plugin. For example, the [Social Login](https://octobercms.com/plugin/flynsarmy-sociallogin) plugin is using your plugin and they are calling `Auth::register()` to register new users but `rainlab.user.register` is never fired! I need this event to check if user has been registered for the first time or they have been already registered and they just logged in.