### PR TITLE
Prevent guest accounts from resetting the account password

### DIFF
--- a/components/ResetPassword.php
+++ b/components/ResetPassword.php
@@ -74,7 +74,8 @@ class ResetPassword extends ComponentBase
             throw new ValidationException($validation);
         }
 
-        if (!$user = UserModel::findByEmail(post('email'))) {
+        $user = UserModel::findByEmail(post('email'));
+        if (!$user || $user->is_guest) {
             throw new ApplicationException(Lang::get(/*A user was not found with the given credentials.*/'rainlab.user::lang.account.invalid_user'));
         }
 


### PR DESCRIPTION
This is a simple fix to correct what I think is an oversight in the password reset process. I believe guest accounts should be treated the same as there being no account. It's confusing to users if they're not sure if they registered, as they can run through a password reset as though they had a registered account, but they still can't log in after that.