### PR TITLE
Fix typo in password reset mail template

### DIFF
--- a/views/mail/restore.htm
+++ b/views/mail/restore.htm
@@ -5,7 +5,7 @@ Hello {{ name }}
 
 Somebody has requested a password reset for your account, if this was not you, please ignore this email.
 
-Use the this activation code to restore your password:
+Use this activation code to restore your password:
 
 {% partial 'promotion' body %}
 {{ code }}


### PR DESCRIPTION
Just a simple typo fix in the default password reset template.