### PR TITLE
Separate management navigation of users and groups.

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -91,6 +91,21 @@ class Plugin extends PluginBase
                 'iconSvg'     => 'plugins/rainlab/user/assets/images/user-icon.svg',
                 'permissions' => ['rainlab.users.*'],
                 'order'       => 500,
+                
+                'sideMenu' => [
+                    'users' => [
+                        'label'       => 'rainlab.user::lang.users.menu_label',
+                        'icon'        => 'icon-user',
+                        'url'         => Backend::url('rainlab/user/users'),
+                        'permissions' => ['acme.blog.access_users']
+                    ],
+                    'groups' => [
+                        'label'       => 'rainlab.user::lang.groups.menu_label',
+                        'icon'        => 'icon-users',
+                        'url'         => Backend::url('rainlab/user/usergroups'),
+                        'permissions' => ['acme.blog.access_groups']
+                    ]
+                ]
             ]
         ];
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -99,7 +99,7 @@ class Plugin extends PluginBase
                         'url'         => Backend::url('rainlab/user/users'),
                         'permissions' => ['acme.blog.access_users']
                     ],
-                    'groups' => [
+                    'usergroups' => [
                         'label'       => 'rainlab.user::lang.groups.menu_label',
                         'icon'        => 'icon-users',
                         'url'         => Backend::url('rainlab/user/usergroups'),

--- a/controllers/usergroups/_list_toolbar.htm
+++ b/controllers/usergroups/_list_toolbar.htm
@@ -1,10 +1,5 @@
 <div data-control="toolbar">
     <a
-        href="<?= Backend::url('rainlab/user/users') ?>"
-        class="btn btn-default oc-icon-chevron-left">
-        <?= e(trans('rainlab.user::lang.groups.return_to_users')) ?>
-    </a>
-    <a
         href="<?= Backend::url('rainlab/user/usergroups/create') ?>"
         class="btn btn-primary oc-icon-plus">
         <?= e(trans('rainlab.user::lang.groups.new_group')) ?>

--- a/controllers/users/_list_toolbar.htm
+++ b/controllers/users/_list_toolbar.htm
@@ -5,12 +5,6 @@
         <?= e(trans('rainlab.user::lang.users.new_user')) ?>
     </a>
 
-    <?php if ($this->user->hasAccess('rainlab.users.access_groups')): ?>
-        <a href="<?= Backend::url('rainlab/user/usergroups') ?>" class="btn btn-default oc-icon-group">
-            <?= e(trans('rainlab.user::lang.groups.all_groups')) ?>
-        </a>
-    <?php endif ?>
-
     <div class="btn-group dropdown dropdown-fixed" data-control="bulk-actions">
         <button
             data-primary-button


### PR DESCRIPTION
This commit could help the readability of user and group management.
This might just be a preference issue but would it not make sense to separate out the navigation of groups from users. My reasoning is that users and groups are different entities.

- Remove "user groups" button from rainlab/users
- Remove "back to users" button from rainlab/usergroups
- Add "Users" and "Groups" side-menu items