### PR TITLE
Fix infinite redirect loop when redirect property set to - none -

### DIFF
--- a/components/Session.php
+++ b/components/Session.php
@@ -92,6 +92,7 @@ class Session extends ComponentBase
                 throw new \InvalidArgumentException('Redirect property is empty');
             }
             
+            $redirectUrl = $this->controller->pageUrl($redirect);
             return Redirect::guest($redirectUrl);
         }
 

--- a/components/Session.php
+++ b/components/Session.php
@@ -77,7 +77,7 @@ class Session extends ComponentBase
      */
     public function init()
     {
-        if (Request::ajax() && !$this->checkUserSecurity()) {
+        if ((Request::ajax() || $this->property('redirect') == '') && !$this->checkUserSecurity()) {
             abort(403, 'Access denied');
         }
     }

--- a/components/Session.php
+++ b/components/Session.php
@@ -88,11 +88,11 @@ class Session extends ComponentBase
     public function onRun()
     {
         if (!$this->checkUserSecurity()) {
-            if ($redirect = $this->property('redirect') == '') {
+            if (empty($this->property('redirect')) {
                 throw new \InvalidArgumentException('Redirect property is empty');
             }
             
-            $redirectUrl = $this->controller->pageUrl($redirect);
+            $redirectUrl = $this->controller->pageUrl($this->property('redirect'));
             return Redirect::guest($redirectUrl);
         }
 

--- a/components/Session.php
+++ b/components/Session.php
@@ -77,7 +77,7 @@ class Session extends ComponentBase
      */
     public function init()
     {
-        if ((Request::ajax() || $this->property('redirect') == '') && !$this->checkUserSecurity()) {
+        if (Request::ajax() && !$this->checkUserSecurity()) {
             abort(403, 'Access denied');
         }
     }
@@ -88,7 +88,10 @@ class Session extends ComponentBase
     public function onRun()
     {
         if (!$this->checkUserSecurity()) {
-            $redirectUrl = $this->controller->pageUrl($this->property('redirect'));
+            if ($redirect = $this->property('redirect') == '') {
+                throw new \InvalidArgumentException('Redirect property is empty');
+            }
+            
             return Redirect::guest($redirectUrl);
         }
 


### PR DESCRIPTION
If redirect on the session component is set to - none - then the page ends in an infinite redirect loop. This adds a check and throws an exception rather than redirecting in that specific case.