### PR TITLE
Bind `rainlab.user.register` event in Plugin.php

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -165,7 +165,8 @@ class Plugin extends PluginBase
         }
 
         Notifier::bindEvents([
-            'rainlab.user.activate' => \RainLab\User\NotifyRules\UserActivatedEvent::class
+            'rainlab.user.activate' => \RainLab\User\NotifyRules\UserActivatedEvent::class,
+            'rainlab.user.register' => \RainLab\User\NotifyRules\UserRegisteredEvent::class
         ]);
 
         Notifier::instance()->registerCallback(function($manager) {


### PR DESCRIPTION
I came across this while troubleshooting an issue wherein the `new_user` email was not being sent upon registration, despite having the Notify plugin installed and a corresponding notification rule created.  After making this change locally, the problem was resolved, leading me to believe that this may have been a simple oversight when the change to the Notify plugin was made.