### PR TITLE
Increase version number

### DIFF
--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -64,3 +64,4 @@
 1.4.3: Fixes session handling for AJAX requests.
 1.4.4: Fixes bug where impersonation touches the last seen timestamp.
 1.4.5: Added token fallback process to Account / Reset Password components when parameter is missing.
+1.4.6: Various bug fixes and translation improvements.


### PR DESCRIPTION
I updated my installation of OctoberCMS to build 434 (where the signature of `October\Rain\Auth\Manager::register` changed) and the plugin was incompatible. I tried to update it in the backend but it does not install any of the commits made after November 26, 2017.
With this commit, all pending commits would be installed.