### PR TITLE
Separate user and group management

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -39,7 +39,7 @@ class Plugin extends PluginBase
         });
 
         App::singleton('redirect', function ($app) {
-            // overrides with our own extended version of Redirector to support 
+            // overrides with our own extended version of Redirector to support
             // seperate url.intended session variable for frontend
             $redirector = new UserRedirector($app['url']);
 
@@ -107,6 +107,21 @@ class Plugin extends PluginBase
                 'iconSvg'     => 'plugins/rainlab/user/assets/images/user-icon.svg',
                 'permissions' => ['rainlab.users.*'],
                 'order'       => 500,
+
+                'sideMenu' => [
+                    'users' => [
+                        'label' => 'rainlab.user::lang.users.menu_label',
+                        'icon'        => 'icon-user',
+                        'url'         => Backend::url('rainlab/user/users'),
+                        'permissions' => ['rainlab.users.access_users']
+                    ],
+                    'usergroups' => [
+                        'label'       => 'rainlab.user::lang.groups.menu_label',
+                        'icon'        => 'icon-users',
+                        'url'         => Backend::url('rainlab/user/usergroups'),
+                        'permissions' => ['rainlab.users.access_groups']
+                    ]
+                ]
             ]
         ];
     }

--- a/controllers/usergroups/_list_toolbar.htm
+++ b/controllers/usergroups/_list_toolbar.htm
@@ -1,10 +1,5 @@
 <div data-control="toolbar">
     <a
-        href="<?= Backend::url('rainlab/user/users') ?>"
-        class="btn btn-default oc-icon-chevron-left">
-        <?= e(trans('rainlab.user::lang.groups.return_to_users')) ?>
-    </a>
-    <a
         href="<?= Backend::url('rainlab/user/usergroups/create') ?>"
         class="btn btn-primary oc-icon-plus">
         <?= e(trans('rainlab.user::lang.groups.new_group')) ?>

--- a/controllers/users/_list_toolbar.htm
+++ b/controllers/users/_list_toolbar.htm
@@ -5,12 +5,6 @@
         <?= e(trans('rainlab.user::lang.users.new_user')) ?>
     </a>
 
-    <?php if ($this->user->hasAccess('rainlab.users.access_groups')): ?>
-        <a href="<?= Backend::url('rainlab/user/usergroups') ?>" class="btn btn-default oc-icon-group">
-            <?= e(trans('rainlab.user::lang.groups.all_groups')) ?>
-        </a>
-    <?php endif ?>
-
     <div class="btn-group dropdown dropdown-fixed" data-control="bulk-actions">
         <button
             data-primary-button


### PR DESCRIPTION
Supersedes #321 

- Added sidemenu items for users and groups
- removed 'back to users' button from groups toolbar
- removed 'groups' button from users toolbar