### PR TITLE
Use settings to determine if a user remains authenticated indefinitely

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -127,6 +127,14 @@ class Account extends ComponentBase
     }
 
     /**
+     * Remember preference for user sessions
+     */
+    public function shouldRemember()
+    {
+        return UserSettings::get('remember_user', true);
+    }
+
+    /**
      * Returns the login label as a word.
      */
     public function loginAttributeLabel()
@@ -194,7 +202,7 @@ class Account extends ComponentBase
 
             Event::fire('rainlab.user.beforeAuthenticate', [$this, $credentials]);
 
-            $user = Auth::authenticate($credentials, true);
+            $user = Auth::authenticate($credentials, $this->shouldRemember());
             if ($user->isBanned()) {
                 Auth::logout();
                 throw new AuthException(/*Sorry, this user is currently not activated. Please contact us for further assistance.*/'rainlab.user::lang.account.banned');

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -86,6 +86,8 @@ return [
         'require_activation_comment' => 'Users must have an activated account to sign in.',
         'use_throttle' => 'Throttle attempts',
         'use_throttle_comment' => 'Repeat failed sign in attempts will temporarily suspend the user.',
+        'remember_user' => 'Remember user',
+        'remember_user_comment' => 'Use a non-expire cookie to keep the user logged in',
         'block_persistence' => 'Prevent concurrent sessions',
         'block_persistence_comment' => 'When enabled users cannot sign in to multiple devices at the same time.',
         'login_attribute' => 'Login attribute',

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -31,6 +31,7 @@ class Settings extends Model
         $this->block_persistence = false;
         $this->allow_registration = true;
         $this->login_attribute = self::LOGIN_EMAIL;
+        $this->remember_user = true;
     }
 
     public function getActivateModeOptions()

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -28,6 +28,14 @@ tabs:
             type: radio
             tab: rainlab.user::lang.settings.signin_tab
 
+        # Remember user with long life cookie
+        remember_user:
+            span: right
+            label: rainlab.user::lang.settings.remember_user
+            comment: rainlab.user::lang.settings.remember_user_comment
+            type: switch
+            tab: rainlab.user::lang.settings.signin_tab
+
         # Require Activation
         allow_registration:
             span: left


### PR DESCRIPTION
This pull request allows the admin to select if users should remain authenticated indefinitely or expire alongside the regular session config.

This also saves the developer from having to re implement the onSignin function from the Account component - just to switch a single parameter.