### PR TITLE
Fix redirect bug

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -488,7 +488,7 @@ class Account extends ComponentBase
 
         $property = $this->property('redirect');
 
-        if (strlen($property) && !$property) {
+        if (!strlen($property)) {
             return;
         }
 


### PR DESCRIPTION
Fixes bug where an empty redirect property will still result in a redirect

```php
// $property = '';
if (strlen($property) && !$property) { // Will evaluate as 0 && true
    return;
}
```