### PR TITLE
Use raw filter on password

### DIFF
--- a/views/mail/invite.htm
+++ b/views/mail/invite.htm
@@ -7,7 +7,7 @@ A user account has been created for you. Please use the following login and pass
 
 {% partial 'panel' body %}
 - Login: `{{ login }}`
-- Password: `{{ password }}`
+- Password: `{{ password|raw }}`
 {% endpartial %}
 
 After signing in you should change your password as soon as possible.


### PR DESCRIPTION
Prevent html characters from being encoded. A password containing html characters is currently being encoded.

For example, the password `123&test` is being sent to the user as `123&amp;test`