### PR TITLE
Allow Preview-Toolbar to be extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ This plugin will fire some global events that can be useful for interacting with
 - **rainlab.user.deactivate**: The user has opted-out of the site by deactivating their account. This should be used to disable any content the user may want removed.
 - **rainlab.user.reactivate**: The user has reactivated their own account by signing back in. This should revive the users content on the site.
 - **rainlab.user.getNotificationVars**: Fires when sending a user notification to enable passing more variables to the email templates. Passes the `$user` model the template will be for.
+- **rainlab.user.extendPreviewToolbar**: Extend User-Preview Toolbar.
 
 Here is an example of hooking an event:
 

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -38,3 +38,4 @@
 </div>
 */
 ?>
+<?= $this->fireViewEvent('rainlab.user.extendPreviewToolbar') ?>


### PR DESCRIPTION
Adds the new Event: **rainlab.user.extendPreviewToolbar** to allow plugin-contributors to extend the Preview-Toolbar.