### PR TITLE
Add an event when a user accesses the website

### DIFF
--- a/components/Session.php
+++ b/components/Session.php
@@ -112,6 +112,7 @@ class Session extends ComponentBase
 
         if (!Auth::isImpersonator()) {
             $user->touchLastSeen();
+            Event::fire('rainlab.user.access');
         }
 
         return $user;

--- a/components/Session.php
+++ b/components/Session.php
@@ -112,7 +112,7 @@ class Session extends ComponentBase
 
         if (!Auth::isImpersonator()) {
             $user->touchLastSeen();
-            Event::fire('rainlab.user.access');
+            Event::fire('rainlab.user.access', [$user]);
         }
 
         return $user;


### PR DESCRIPTION
I need to track statistics about user access. The existing events are insufficient, as my users can maintain a session for a long time. Some users log in once, and maintain the same session for months.

The `last_seen` column is also insufficient, as I need to track the evolution of user activity over time.

This seems like the appropriate place to fire an event that indicates a user has accessed the website, whether with an existing session or after a successful log in.