### PR TITLE
IP logging and Registration throttle

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -589,6 +589,10 @@ class Account extends ComponentBase
      */
     protected function isRegisterThrottled()
     {
+        if (!UserSettings::get('use_register_throttle', true)) {
+            return false;
+        }
+
         return UserModel::isRegisterThrottled(Request::ip());
     }
 }

--- a/components/Account.php
+++ b/components/Account.php
@@ -589,7 +589,7 @@ class Account extends ComponentBase
      */
     protected function isRegisterThrottled()
     {
-        if (!UserSettings::get('use_register_throttle', true)) {
+        if (!UserSettings::get('use_register_throttle', false)) {
             return false;
         }
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -89,6 +89,8 @@ return [
         'require_activation_comment' => 'Users must have an activated account to sign in.',
         'use_throttle' => 'Throttle attempts',
         'use_throttle_comment' => 'Repeat failed sign in attempts will temporarily suspend the user.',
+        'use_register_throttle' => 'Throttle registration',
+        'use_register_throttle_comment' => 'Prevent multiple registrations from the same IP in short succession.',
         'block_persistence' => 'Prevent concurrent sessions',
         'block_persistence_comment' => 'When enabled users cannot sign in to multiple devices at the same time.',
         'login_attribute' => 'Login attribute',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -132,6 +132,8 @@ return [
         'status_guest' => 'Guest',
         'status_activated' => 'Activated',
         'status_registered' => 'Registered',
+        'created_ip_address' => 'Created IP Address',
+        'last_ip_address' => 'Last IP Address',
     ],
     'group' => [
         'label' => 'Group',
@@ -183,6 +185,7 @@ return [
         'already_active' => 'Your account is already activated!',
         'activation_email_sent' => 'An activation email has been sent to your email address.',
         'registration_disabled' => 'Registrations are currently disabled.',
+        'registration_throttled' => 'Registration is throttled. Please try again later.',
         'sign_in' => 'Sign in',
         'register' => 'Register',
         'full_name' => 'Full Name',

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -38,6 +38,7 @@ class Settings extends Model
         $this->update_requires_password = false;
         $this->remember_login = self::REMEMBER_ALWAYS;
         $this->min_password_length = self::MIN_PASSWORD_LENGTH_DEFAULT;
+        $this->use_register_throttle = true;
     }
 
     public function getActivateModeOptions()

--- a/models/User.php
+++ b/models/User.php
@@ -376,7 +376,7 @@ class User extends UserBase
 
     /**
      * Returns true if IP address is throttled and cannot register
-     * again. Maximum 3 registrations every 15 minutes.
+     * again. Maximum 3 registrations every 60 minutes.
      * @return bool
      */
     public static function isRegisterThrottled($ipAddress)
@@ -385,7 +385,7 @@ class User extends UserBase
             return false;
         }
 
-        $timeLimit = Carbon::now()->subMinutes(15);
+        $timeLimit = Carbon::now()->subMinutes(60);
         $count = static::make()
             ->where('created_ip_address', $ipAddress)
             ->where('created_at', '>', $timeLimit)

--- a/models/User.php
+++ b/models/User.php
@@ -378,6 +378,7 @@ class User extends UserBase
     /**
      * Returns true if IP address is throttled and cannot register
      * again. Maximum 3 registrations every 60 minutes.
+     * @param string|null $ipAddress
      * @return bool
      */
     public static function isRegisterThrottled($ipAddress)

--- a/models/User.php
+++ b/models/User.php
@@ -363,6 +363,7 @@ class User extends UserBase
 
     /**
      * Records the last_ip_address to reflect the last known IP for this user.
+     * @param string|null $ipAddress
      * @return void
      */
     public function touchIpAddress($ipAddress)

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -30,7 +30,7 @@ tabs:
 
         # Remeber Login Mode
         remember_login:
-            span: left
+            span: right
             label: rainlab.user::lang.settings.remember_login
             commentAbove: rainlab.user::lang.settings.remember_login_comment
             type: radio
@@ -41,6 +41,14 @@ tabs:
             span: left
             label: rainlab.user::lang.settings.allow_registration
             comment: rainlab.user::lang.settings.allow_registration_comment
+            type: switch
+            tab: rainlab.user::lang.settings.registration_tab
+
+        # Require Activation
+        use_register_throttle:
+            span: right
+            label: rainlab.user::lang.settings.use_register_throttle
+            comment: rainlab.user::lang.settings.use_register_throttle_comment
             type: switch
             tab: rainlab.user::lang.settings.registration_tab
 

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -44,7 +44,7 @@ tabs:
             type: switch
             tab: rainlab.user::lang.settings.registration_tab
 
-        # Require Activation
+        # Enable registration throttling
         use_register_throttle:
             span: right
             label: rainlab.user::lang.settings.use_register_throttle

--- a/models/user/columns.yaml
+++ b/models/user/columns.yaml
@@ -38,3 +38,13 @@ columns:
         label: rainlab.user::lang.user.is_guest
         type: switch
         invisible: true
+
+    created_ip_address:
+        label: rainlab.user::lang.user.created_ip_address
+        searchable: true
+        invisible: true
+
+    last_ip_address:
+        label: rainlab.user::lang.user.last_ip_address
+        searchable: true
+        invisible: true

--- a/models/user/fields.yaml
+++ b/models/user/fields.yaml
@@ -70,6 +70,20 @@ tabs:
             type: relation
             emptyOption: rainlab.user::lang.user.empty_groups
 
+        created_ip_address:
+            label: rainlab.user::lang.user.created_ip_address
+            span: auto
+            disabled: true
+            tab: rainlab.user::lang.user.account
+            context: preview
+
+        last_ip_address:
+            label: rainlab.user::lang.user.last_ip_address
+            span: auto
+            disabled: true
+            tab: rainlab.user::lang.user.account
+            context: preview
+
 secondaryTabs:
     fields:
 

--- a/updates/users_add_ip_address.php
+++ b/updates/users_add_ip_address.php
@@ -1,0 +1,28 @@
+<?php namespace RainLab\User\Updates;
+
+use Carbon\Carbon;
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class UsersAddIpAddress extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function($table)
+        {
+            $table->string('created_ip_address')->nullable();
+            $table->string('last_ip_address')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        if (Schema::hasColumn('users', 'created_ip_address')) {
+            Schema::table('users', function($table)
+            {
+                $table->dropColumn('created_ip_address');
+                $table->dropColumn('last_ip_address');
+            });
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -69,5 +69,5 @@
 1.4.8: Fixes a bug where calling MailBlocker::removeBlock could remove all mail blocks for the user.
 1.5.0: !!! Required password length is now a minimum of 8 characters. Previous passwords will not be affected until the next password change.
 1.5.1:
-    - User IP addresses are now logged. Introduce registration throttle.
+    - User IP addresses are now logged. Introduce registration throttle and "remember login" functionality.
     - users_add_ip_address.php

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -68,3 +68,6 @@
 1.4.7: Fixes redirect bug in Account component / Update translations and separate user and group management.
 1.4.8: Fixes a bug where calling MailBlocker::removeBlock could remove all mail blocks for the user.
 1.5.0: !!! Required password length is now a minimum of 8 characters. Previous passwords will not be affected until the next password change.
+1.5.1:
+    - User IP addresses are now logged. Introduce registration throttle.
+    - users_add_ip_address.php


### PR DESCRIPTION
Introduces IP logging for user accounts. The registration throttle prevents an issue where bots spam registration with dummy accounts.