### PR TITLE
Add whitespace trimming to login

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -204,6 +204,8 @@ class Account extends ComponentBase
             if (!array_key_exists('login', $data)) {
                 $data['login'] = post('username', post('email'));
             }
+            
+            $data['login'] = trim($data['login']);
 
             $validation = Validator::make($data, $rules);
             if ($validation->fails()) {


### PR DESCRIPTION
I have had several instances of users trying to log in and authenticating failing because they have whitespace in their email address which is obviously difficult to see on the screen. While this is technically a case of user error, I think that adding whitespace trimming would make the login system more user friendly to less technical users.