### PR TITLE
* apply password length settings to validation rules in constructor. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+.idea

--- a/models/User.php
+++ b/models/User.php
@@ -30,6 +30,13 @@ class User extends UserBase
         'password_confirmation' => 'required_with:password|between:8,255',
     ];
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->applyPasswordLengthSettings();
+    }
+
     /**
      * @var array Relations
      */
@@ -247,7 +254,10 @@ class User extends UserBase
         ) {
             $this->username = $this->email;
         }
+    }
 
+    protected function applyPasswordLengthSettings()
+    {
         /*
          * Apply Password Length Settings
          */


### PR DESCRIPTION
…Fix actualize validation rules in Account::onRegister

In onRegister method the code `$rules = (new UserModel)->rules;` fetched not actual validation rules (without applyMinPasswordLength). Then commit fix it and add `__constructor` method into User model class.