### PR TITLE
No longer require password field for onUpdate handler

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -419,7 +419,7 @@ class Account extends ComponentBase
         /*
          * Password has changed, reauthenticate the user
          */
-        if (strlen($data['password'])) {
+        if (array_key_exists('password', $data) && strlen($data['password'])) {
             Auth::login($user->reload(), true);
         }
 


### PR DESCRIPTION
This allows to split the account edition into multiple partials, and still uses the onUpdate handler, having for instance one page only for e-mail editing.

Before, error was thrown line 422 when missing password field.