### PR TITLE
Fix intended redirect on register success

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -325,17 +325,20 @@ class Account extends ComponentBase
                 Flash::success(Lang::get(/*An activation email has been sent to your email address.*/'rainlab.user::lang.account.activation_email_sent'));
             }
 
+            $intended = false;
+            
             /*
              * Automatically activated or not required, log the user in
              */
             if ($automaticActivation || !$requireActivation) {
                 Auth::login($user);
+                $intended = true;
             }
 
             /*
              * Redirect to the intended page after successful sign in
              */
-            if ($redirect = $this->makeRedirection(true)) {
+            if ($redirect = $this->makeRedirection($intended)) {
                 return $redirect;
             }
         }


### PR DESCRIPTION
Upon successfully registering a user, they are always redirected to their intended page, even when they are not activated. 

This is confusing, because that intended page is usually behind a login wall, which they can't login to yet while their account isn't activated. 

More elegant solution would be to only redirect the user to their intended page if they are automatically activated (and therefore logged in). If they are not, it might make more sense to redirect them to a page specified in the component's redirect parameter. 