### PR TITLE
Unsuspend a user from user preview

### DIFF
--- a/controllers/Users.php
+++ b/controllers/Users.php
@@ -1,6 +1,7 @@
 <?php namespace RainLab\User\Controllers;
 
 use Auth;
+use Illuminate\Support\Facades\Redirect;
 use Lang;
 use Flash;
 use Response;
@@ -248,9 +249,7 @@ class Users extends Controller
 
         Flash::success(Lang::get('backend::lang.form.delete_success'));
 
-        if ($redirect = $this->makeRedirect('delete', $model)) {
-            return $redirect;
-        }
+        return Redirect::refresh();
     }
 
     /**

--- a/controllers/Users.php
+++ b/controllers/Users.php
@@ -222,6 +222,22 @@ class Users extends Controller
     }
 
     /**
+     * Unsuspend this user
+     */
+    public function preview_onUnsuspendUser($recordId)
+    {
+        $model = $this->formFindModelObject($recordId);
+
+        $model->unsuspend();
+
+        Flash::success(Lang::get('rainlab.user::lang.users.unsuspend_success'));
+
+        if ($redirect = $this->makeRedirect('update-close', $model)) {
+            return $redirect;
+        }
+    }
+
+    /**
      * Force delete a user.
      */
     public function update_onDelete($recordId = null)

--- a/controllers/Users.php
+++ b/controllers/Users.php
@@ -1,7 +1,7 @@
 <?php namespace RainLab\User\Controllers;
 
 use Auth;
-use Illuminate\Support\Facades\Redirect;
+use Redirect;
 use Lang;
 use Flash;
 use Response;

--- a/controllers/Users.php
+++ b/controllers/Users.php
@@ -1,10 +1,10 @@
 <?php namespace RainLab\User\Controllers;
 
 use Auth;
-use Redirect;
 use Lang;
 use Flash;
 use Response;
+use Redirect;
 use BackendMenu;
 use BackendAuth;
 use Backend\Classes\Controller;
@@ -233,9 +233,7 @@ class Users extends Controller
 
         Flash::success(Lang::get('rainlab.user::lang.users.unsuspend_success'));
 
-        if ($redirect = $this->makeRedirect('update-close', $model)) {
-            return $redirect;
-        }
+        return Redirect::refresh();
     }
 
     /**
@@ -249,7 +247,9 @@ class Users extends Controller
 
         Flash::success(Lang::get('backend::lang.form.delete_success'));
 
-        return Redirect::refresh();
+        if ($redirect = $this->makeRedirect('delete', $model)) {
+            return $redirect;
+        }
     }
 
     /**

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -23,7 +23,7 @@
         href="javascript:;"
         data-request="onUnsuspendUser"
         data-request-confirm="<?= e(trans('rainlab.user::lang.users.unsuspend_confirm')) ?>"
-        class="btn btn-default oc-icon-undo">
+        class="btn btn-default oc-icon-unlock-alt">
         <?= e(trans('rainlab.user::lang.users.unsuspend')) ?>
     </a>
 <?php endif ?>

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -19,13 +19,13 @@
 <?php endif ?>
 
 <?php if ($formModel->isSuspended()): ?>
-<a
-    href="javascript:;"
-    data-request="onUnsuspendUser"
-    data-request-confirm="<?= e(trans('rainlab.user::lang.users.unsuspend_confirm')) ?>"
-    class="btn btn-default oc-icon-undo">
-    <?= e(trans('rainlab.user::lang.users.unsuspend')) ?>
-</a>
+    <a
+        href="javascript:;"
+        data-request="onUnsuspendUser"
+        data-request-confirm="<?= e(trans('rainlab.user::lang.users.unsuspend_confirm')) ?>"
+        class="btn btn-default oc-icon-undo">
+        <?= e(trans('rainlab.user::lang.users.unsuspend')) ?>
+    </a>
 <?php endif ?>
 
 <?php

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -18,6 +18,7 @@
     </a>
 <?php endif ?>
 
+<?php if ($formModel->isSuspended()): ?>
 <a
     href="javascript:;"
     data-request="onUnsuspendUser"
@@ -25,6 +26,7 @@
     class="btn btn-default oc-icon-undo">
     <?= e(trans('rainlab.user::lang.users.unsuspend')) ?>
 </a>
+<?php endif ?>
 
 <?php
 /* @todo

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -17,6 +17,15 @@
         <?= e(trans('rainlab.user::lang.users.impersonate_user')) ?>
     </a>
 <?php endif ?>
+
+<a
+    href="javascript:;"
+    data-request="onUnsuspendUser"
+    data-request-confirm="<?= e(trans('rainlab.user::lang.users.unsuspend_confirm')) ?>"
+    class="btn btn-default oc-icon-undo">
+    <?= e(trans('rainlab.user::lang.users.unsuspend')) ?>
+</a>
+
 <?php
 /* @todo
 <div class="btn-group">

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -63,6 +63,9 @@ return [
         'unban_selected_confirm' => 'Unban the selected users?',
         'unban_selected_empty' => 'There are no selected users to unban.',
         'unban_selected_success' => 'Successfully unbanned the selected users.',
+        'unsuspend' => 'Unsuspend',
+        'unsuspend_success' => 'User has been unsuspended.',
+        'unsuspend_confirm' => 'Unsuspend this user?'
     ],
     'settings' => [
         'users' => 'Users',

--- a/models/User.php
+++ b/models/User.php
@@ -358,6 +358,19 @@ class User extends UserBase
     }
 
     //
+    // Suspending
+    //
+
+    /**
+     * Remove the ban on this user.
+     * @return void
+     */
+    public function unsuspend()
+    {
+        Auth::findThrottleByUserId($this->id)->unsuspend();
+    }
+
+    //
     // IP Recording and Throttle
     //
 

--- a/models/User.php
+++ b/models/User.php
@@ -362,7 +362,16 @@ class User extends UserBase
     //
 
     /**
-     * Remove the ban on this user.
+     * Check if the user is suspended.
+     * @return bool
+     */
+    public function isSuspended()
+    {
+        return Auth::findThrottleByUserId($this->id)->checkSuspended();
+    }
+
+    /**
+     * Remove the suspension on this user.
      * @return void
      */
     public function unsuspend()


### PR DESCRIPTION
During my first OctoberCMS project, I kept forgetting the user password for my test user. Having forgotten these passwords I had to manually keep clearing the user throttle table. Adding this will allow a quick way to remove the suspension on a user account not just useful for testing but also for further use within an application.