### PR TITLE
Update User.php

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -55,6 +55,13 @@ class User extends UserBase
         'created_ip_address',
         'last_ip_address'
     ];
+    
+    /**
+     * Reset guarded fields, because we use $fillable instead.
+     * @var array The attributes that aren't mass assignable.
+     */
+    protected $guarded = ['*'];
+
 
     /**
      * Purge attributes from data set.


### PR DESCRIPTION
Reset guarded fields, because we use $fillable instead.

related to https://github.com/rainlab/userplus-plugin/pull/35#issuecomment-622323509

related to:  
https://github.com/rainlab/user-plugin/pull/33
https://github.com/rainlab/userplus-plugin/pull/35
https://github.com/rainlab/location-plugin/issues/52

fixes:
https://github.com/rainlab/userplus-plugin/issues/34



