### PR TITLE
Add remember option to registration

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -338,22 +338,7 @@ class Account extends ComponentBase
              * Automatically activated or not required, log the user in
              */
             if ($automaticActivation || !$requireActivation) {
-                /*
-                * Login remember mode
-                */
-                switch ($this->rememberLoginMode()) {
-                    case UserSettings::REMEMBER_ALWAYS:
-                        $remember = true;
-                        break;
-                    case UserSettings::REMEMBER_NEVER:
-                        $remember = false;
-                        break;
-                    case UserSettings::REMEMBER_ASK:
-                        $remember = (bool) array_get($data, 'remember', false);
-                        break;
-                }
-
-                Auth::login($user, $remember);
+                Auth::login($user, $this->rememberLoginMode() === UserSettings::REMEMBER_ALWAYS);
             }
 
             /*

--- a/components/Account.php
+++ b/components/Account.php
@@ -338,7 +338,22 @@ class Account extends ComponentBase
              * Automatically activated or not required, log the user in
              */
             if ($automaticActivation || !$requireActivation) {
-                Auth::login($user);
+                /*
+                * Login remember mode
+                */
+                switch ($this->rememberLoginMode()) {
+                    case UserSettings::REMEMBER_ALWAYS:
+                        $remember = true;
+                        break;
+                    case UserSettings::REMEMBER_NEVER:
+                        $remember = false;
+                        break;
+                    case UserSettings::REMEMBER_ASK:
+                        $remember = (bool) array_get($data, 'remember', false);
+                        break;
+                }
+
+                Auth::login($user, $remember);
             }
 
             /*


### PR DESCRIPTION
Following #312 

On registration, in case the automatic Activation is ON or the settings do not require activation, shouldn't we add the remember option in the registration as well? So we don't get the persistent session by default in the first login?