### PR TITLE
Fix SQL Server 2017 error during migration: "There is already an obje…

### DIFF
--- a/updates/create_user_groups_table.php
+++ b/updates/create_user_groups_table.php
@@ -23,7 +23,7 @@ class CreateUserGroupsTable extends Migration
             $table->engine = 'InnoDB';
             $table->integer('user_id')->unsigned();
             $table->integer('user_group_id')->unsigned();
-            $table->primary(['user_id', 'user_group_id'], 'user_group');
+            $table->primary(['user_id', 'user_group_id'], 'rainlab_user_group');
         });
     }
 


### PR DESCRIPTION
"There is already an object named 'user_group' in the database."
by simply renaming the index name