### PR TITLE
Correcting 'Full Name' to 'Name'

### DIFF
--- a/components/account/update.htm
+++ b/components/account/update.htm
@@ -1,7 +1,7 @@
 {{ form_ajax('onUpdate') }}
 
     <div class="form-group">
-        <label for="accountName">Full Name</label>
+        <label for="accountName">Name</label>
         <input name="name" type="text" class="form-control" id="accountName" value="{{ user.name }}">
     </div>
 


### PR DESCRIPTION
As the model has a 'surname' property, prompting a user to enter their 'full name' will often result in 'doubling' the surname (once in the 'name' column, and again in the 'surname' column)