### PR TITLE
Feature to extend user preview and listing toolbars

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -34,7 +34,7 @@ class Plugin extends PluginBase
         $alias = AliasLoader::getInstance();
         $alias->alias('Auth', 'RainLab\User\Facades\Auth');
 
-        App::singleton('user.auth', function() {
+        App::singleton('user.auth', function () {
             return \RainLab\User\Classes\AuthManager::instance();
         });
 
@@ -56,7 +56,7 @@ class Plugin extends PluginBase
         /*
          * Apply user-based mail blocking
          */
-        Event::listen('mailer.prepareSend', function($mailer, $view, $message) {
+        Event::listen('mailer.prepareSend', function ($mailer, $view, $message) {
             return MailBlocker::filterMessage($view, $message);
         });
 
@@ -184,7 +184,7 @@ class Plugin extends PluginBase
             'rainlab.user.register' => \RainLab\User\NotifyRules\UserRegisteredEvent::class
         ]);
 
-        Notifier::instance()->registerCallback(function($manager) {
+        Notifier::instance()->registerCallback(function ($manager) {
             $manager->registerGlobalParams([
                 'user' => Auth::getUser()
             ]);

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ This plugin will fire some global events that can be useful for interacting with
 - **rainlab.user.deactivate**: The user has opted-out of the site by deactivating their account. This should be used to disable any content the user may want removed.
 - **rainlab.user.reactivate**: The user has reactivated their own account by signing back in. This should revive the users content on the site.
 - **rainlab.user.getNotificationVars**: Fires when sending a user notification to enable passing more variables to the email templates. Passes the `$user` model the template will be for.
+- **rainlab.user.extendListToolbar**: Fires when the user listing page's toolbar is rendered.
+- **rainlab.user.extendPreviewToolbar**: Fires when the user preview page's toolbar is rendered.
 
 Here is an example of hooking an event:
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This plugin makes use of October's [`Flash API`](http://octobercms.com/docs/mark
 The User plugin displays AJAX error messages in a simple ``alert()``-box by default. However, this might scare non-technical users. You can change the default behavior of an AJAX error from displaying an ``alert()`` message, like this:
 
     <script>
-        $(window).on('ajaxErrorMessage', function(event, message){
+        $(window).on('ajaxErrorMessage', function (event, message){
 
             // This can be any custom JavaScript you want
             alert('Something bad happened, mate, here it is: ' + message);
@@ -310,8 +310,8 @@ This plugin will fire some global events that can be useful for interacting with
 - **rainlab.user.deactivate**: The user has opted-out of the site by deactivating their account. This should be used to disable any content the user may want removed.
 - **rainlab.user.reactivate**: The user has reactivated their own account by signing back in. This should revive the users content on the site.
 - **rainlab.user.getNotificationVars**: Fires when sending a user notification to enable passing more variables to the email templates. Passes the `$user` model the template will be for.
-- **rainlab.user.extendListToolbar**: Fires when the user listing page's toolbar is rendered.
-- **rainlab.user.extendPreviewToolbar**: Fires when the user preview page's toolbar is rendered.
+- **rainlab.user.view.extendListToolbar**: Fires when the user listing page's toolbar is rendered.
+- **rainlab.user.view.extendPreviewToolbar**: Fires when the user preview page's toolbar is rendered.
 
 Here is an example of hooking an event:
 

--- a/controllers/users/_list_toolbar.htm
+++ b/controllers/users/_list_toolbar.htm
@@ -71,8 +71,10 @@
          *
          * Example usage:
          *
-         *     Event::listen('rainlab.user.extendListToolbar', function ($controller) {
-         *         // return your HTML here
+         *     Event::listen('rainlab.user.extendListToolbar', function (
+         *         (RainLab\User\Controllers\Users) $controller
+         *     ) {
+         *         return $controller->makePartial('~/path/to/partial');
          *     });
          *
          */

--- a/controllers/users/_list_toolbar.htm
+++ b/controllers/users/_list_toolbar.htm
@@ -66,19 +66,19 @@
 
     <?=
         /**
-         * @event rainlab.user.extendListToolbar
+         * @event rainlab.user.view.extendListToolbar
          * Fires when user list toolbar is rendered.
          *
          * Example usage:
          *
-         *     Event::listen('rainlab.user.extendListToolbar', function (
+         *     Event::listen('rainlab.user.view.extendListToolbar', function (
          *         (RainLab\User\Controllers\Users) $controller
          *     ) {
          *         return $controller->makePartial('~/path/to/partial');
          *     });
          *
          */
-        $this->fireViewEvent('rainlab.user.extendListToolbar');
+        $this->fireViewEvent('rainlab.user.view.extendListToolbar');
     ?>
 
 </div>

--- a/controllers/users/_list_toolbar.htm
+++ b/controllers/users/_list_toolbar.htm
@@ -64,4 +64,19 @@
         </ul>
     </div>
 
+    <?=
+        /**
+         * @event rainlab.user.extendListToolbar
+         * Fires when user list toolbar is rendered.
+         *
+         * Example usage:
+         *
+         *     Event::listen('rainlab.user.extendListToolbar', function ($controller) {
+         *         // return your HTML here
+         *     });
+         *
+         */
+        $this->fireViewEvent('rainlab.user.extendListToolbar');
+    ?>
+
 </div>

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -57,8 +57,11 @@
      *
      * Example usage:
      *
-     *     Event::listen('rainlab.user.extendPreviewToolbar', function ($controller, $record) {
-     *         // return your HTML here
+     *     Event::listen('rainlab.user.extendPreviewToolbar', function (
+     *         (RainLab\User\Controllers\Users) $controller,
+     *         (RainLab\User\Models\User) $record
+     *     ) {
+     *         return $controller->makePartial('~/path/to/partial');
      *     });
      *
      */

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -49,3 +49,20 @@
 </div>
 */
 ?>
+
+<?=
+    /**
+     * @event rainlab.user.extendPreviewToolbar
+     * Fires when preview user toolbar is rendered.
+     *
+     * Example usage:
+     *
+     *     Event::listen('rainlab.user.extendPreviewToolbar', function ($controller, $record) {
+     *         // return your HTML here
+     *     });
+     *
+     */
+    $this->fireViewEvent('rainlab.user.extendPreviewToolbar', [
+        'record' => $formModel
+    ]);
+?>

--- a/controllers/users/_preview_toolbar.htm
+++ b/controllers/users/_preview_toolbar.htm
@@ -52,12 +52,12 @@
 
 <?=
     /**
-     * @event rainlab.user.extendPreviewToolbar
+     * @event rainlab.user.view.extendPreviewToolbar
      * Fires when preview user toolbar is rendered.
      *
      * Example usage:
      *
-     *     Event::listen('rainlab.user.extendPreviewToolbar', function (
+     *     Event::listen('rainlab.user.view.extendPreviewToolbar', function (
      *         (RainLab\User\Controllers\Users) $controller,
      *         (RainLab\User\Models\User) $record
      *     ) {
@@ -65,7 +65,7 @@
      *     });
      *
      */
-    $this->fireViewEvent('rainlab.user.extendPreviewToolbar', [
+    $this->fireViewEvent('rainlab.user.view.extendPreviewToolbar', [
         'record' => $formModel
     ]);
 ?>


### PR DESCRIPTION
Added view extension events that can be used to extend the toolbars on the user listing and preview page. This supersedes PR #391.