### PR TITLE
Replace obsolete status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Front-end user plugin
 
-[![Build Status](https://img.shields.io/travis/rainlab/user-plugin.svg?branch=master)](https://travis-ci.org/rainlab/user-plugin)
+[![Build Status](https://img.shields.io/github/workflow/status/rainlab/user-plugin/Tests)](https://github.com/rainlab/user-plugin/actions)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/rainlab/user-plugin/blob/master/LICENCE.md)
 
 Front-end user management for October CMS.


### PR DESCRIPTION
Tests are run with GitHub Actions now