### PR TITLE
Remove type hint

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -151,7 +151,7 @@ class User extends UserBase
     /**
      * clearPersistCode will forcibly sign the user out
      */
-    public function clearPersistCode(): void
+    public function clearPersistCode()
     {
         $this->persist_code = null;
         $this->timestamps = false;


### PR DESCRIPTION
If you try to deactivate user in the CMS via "Deactivate selected" dropbox on the users list, it throws an error:
Type error: Return value of RainLab\User\Models\User::clearPersistCode() must be an instance of RainLab\User\Models\void, none returned" on line 159 of \plugins\rainlab\user\models\User.php

Removing the type hint solves the problem.