### PR TITLE
New event rainlab.user.extendUserAuthQuery

### DIFF
--- a/classes/AuthManager.php
+++ b/classes/AuthManager.php
@@ -55,7 +55,7 @@ class AuthManager extends RainAuthManager
     {
         $query = $this->createUserModelQuery();
 
-        $user = $query->where('email', $email);
+        $user = $query->where('email', $email)->first();
 
         return $this->validateUserModel($user) ? $user : null;
     }

--- a/classes/AuthManager.php
+++ b/classes/AuthManager.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\User\Classes;
 
+use Event;
 use October\Rain\Auth\Manager as RainAuthManager;
 use RainLab\User\Models\Settings as UserSettings;
 use RainLab\User\Models\UserGroup as UserGroupModel;
@@ -29,6 +30,7 @@ class AuthManager extends RainAuthManager
     public function extendUserQuery($query)
     {
         $query->withTrashed();
+        Event::fire('rainlab.user.extendUserAuthQuery', [$query]);
     }
 
     /**
@@ -41,6 +43,21 @@ class AuthManager extends RainAuthManager
         }
 
         return parent::register($credentials, $activate, $autoLogin);
+    }
+
+
+    /**
+     * findUserByEmail finds a user by the email value.
+     * @param string $email
+     * @return Authenticatable|null
+     */
+    public function findUserByEmail($email)
+    {
+        $query = $this->createUserModelQuery();
+
+        $user = $query->where('email', $email);
+
+        return $this->validateUserModel($user) ? $user : null;
     }
 
     //

--- a/components/ResetPassword.php
+++ b/components/ResetPassword.php
@@ -91,7 +91,7 @@ class ResetPassword extends ComponentBase
             throw new ValidationException($validation);
         }
 
-        $user = UserModel::findByEmail(post('email'));
+        $user = Auth::findUserByEmail(post('email'));
         if (!$user || $user->is_guest) {
             throw new ApplicationException(Lang::get(/*A user was not found with the given credentials.*/'rainlab.user::lang.account.invalid_user'));
         }

--- a/components/ResetPassword.php
+++ b/components/ResetPassword.php
@@ -92,7 +92,7 @@ class ResetPassword extends ComponentBase
         }
 
         $user = Auth::findUserByEmail(post('email'));
-        if (!$user || $user->is_guest) {
+        if (!$user || $user->is_guest || $user->trashed()) {
             throw new ApplicationException(Lang::get(/*A user was not found with the given credentials.*/'rainlab.user::lang.account.invalid_user'));
         }
 


### PR DESCRIPTION
This pull request creates a new event that will help 3rd party plugins extend the main user query used by the AuthManager.

The Reset Password was also updated to use the AuthManager's user query triggering the new event like the other components