### PR TITLE
Added missing variables for the 'invite_email' mail view

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -418,6 +418,12 @@ class User extends Model implements Authenticatable, CanResetPassword
      */
     public function getNotificationVars(): array
     {
+        $url = Cms::entryUrl('resetPassword') . '?' . http_build_query([
+                'reset' => Password::createToken($user),
+                'email' => $user->getEmailForPasswordReset(),
+                'new'   => true
+            ]);
+        
         $vars = [
             'full_name' => $this->full_name,
             'first_name' => $this->first_name,
@@ -425,6 +431,8 @@ class User extends Model implements Authenticatable, CanResetPassword
             'login' => $this->login,
             'email' => $this->email,
             'username' => $this->username,
+            'url' => $url,
+            'count' => Config::get('auth.passwords.users.expire'),
         ];
 
         // Extensibility


### PR DESCRIPTION
The 'invite_email' mail view lacks some variables. This PR adds the missing variables:

- **url** to the password page
- **count** time before link expiration

The URL is generated based on the example for the password reset email view.