### PR TITLE
Fixing typos and missing rules field in UserImport model

### DIFF
--- a/models/user/UserImport.php
+++ b/models/user/UserImport.php
@@ -7,12 +7,17 @@ use Exception;
 /**
  * UserExport Model
  */
-class UserExport extends ImportModel
+class UserImport extends ImportModel
 {
     /**
      * @var string table used by the model
      */
     protected $table = 'users';
+
+    /**
+     * @var array rules
+     */
+    public $rules = [];
 
     /**
      * importData


### PR DESCRIPTION
I wanted to use import, but i get error "Error: Class "RainLab\User\Models\User\UserImport"",
 when i inspected the code it's look like there is some typos and missing field.
After this changes it's works.