### PR TITLE
Fix : Notifications array_merge when array with NULL value

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -429,7 +429,7 @@ class User extends Model implements Authenticatable, CanResetPassword
         // Extensibility
         $result = Event::fire('rainlab.user.getNotificationVars', [$this]);
         if ($result && is_array($result)) {
-            $vars = call_user_func_array('array_merge', $result) + $vars;
+            $vars = call_user_func_array('array_merge', array_filter($result)) + $vars;
         }
 
         return $vars;


### PR DESCRIPTION
Avoid array_merge error when passing an array with a NULL value.

Append when asking a password recovery

TypeError: array_merge(): Argument #1 must be of type array, null given in /plugins/rainlab/user/models/User.php:434
