### PR TITLE
Last name is not required

### DIFF
--- a/components/Registration.php
+++ b/components/Registration.php
@@ -104,14 +104,14 @@ class Registration extends ComponentBase
 
         Validator::make($input, [
             'first_name' => ['required', 'string', 'max:255'],
-            'last_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => UserHelper::passwordRules(),
         ])->validate();
 
         $user = User::create([
             'first_name' => $input['first_name'],
-            'last_name' => $input['last_name'],
+            'last_name' => $input['last_name'] ?? null,
             'email' => $input['email'],
             'password' => $input['password'],
             'password_confirmation' => $input['password_confirmation'],

--- a/models/user/HasModelAttributes.php
+++ b/models/user/HasModelAttributes.php
@@ -32,7 +32,7 @@ trait HasModelAttributes
      */
     public function getFullNameAttribute()
     {
-        return "{$this->first_name} {$this->last_name}";
+        return trim("{$this->first_name} {$this->last_name}");
     }
 
     /**


### PR DESCRIPTION
Fixes #592 and also trims extra white space when getting full_name, if last_name is empty.