### PR TITLE
Adjusts user group navigation

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -174,6 +174,12 @@ class Plugin extends PluginBase
                         'url' => Backend::url('rainlab/user/users'),
                         'permissions' => ['rainlab.users.access_users']
                     ],
+                    'usergroups' => [
+                        'label' => "User Groups",
+                        'icon' => 'icon-users',
+                        'url' => Backend::url('rainlab/user/usergroups'),
+                        'permissions' => ['rainlab.users.access_groups']
+                    ],
                 ]
             ]
         ];

--- a/controllers/UserGroups.php
+++ b/controllers/UserGroups.php
@@ -43,6 +43,6 @@ class UserGroups extends Controller
     {
         parent::__construct();
 
-        BackendMenu::setContext('RainLab.User', 'user', 'users');
+        BackendMenu::setContext('RainLab.User', 'user', 'usergroups');
     }
 }

--- a/controllers/usergroups/_list_toolbar.php
+++ b/controllers/usergroups/_list_toolbar.php
@@ -1,4 +1,3 @@
 <div data-control="toolbar">
-    <?= Ui::button("Back", 'user/users')->icon('icon-arrow-left') ?>
     <?= Ui::button("New Group", 'user/usergroups/create')->primary()->icon('icon-plus') ?>
 </div>

--- a/controllers/usergroups/config_list.yaml
+++ b/controllers/usergroups/config_list.yaml
@@ -30,9 +30,9 @@ showSetup: true
 showSorting: true
 
 # Default sorting column
-# defaultSort:
-#     column: created_at
-#     direction: desc
+defaultSort:
+    column: name
+    direction: asc
 
 # Display checkboxes next to each record
 # showCheckboxes: true

--- a/controllers/usergroups/create.php
+++ b/controllers/usergroups/create.php
@@ -1,6 +1,5 @@
 <?php Block::put('breadcrumb') ?>
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="<?= Backend::url('user/users') ?>"><?= __("Users") ?></a></li>
         <li class="breadcrumb-item"><a href="<?= Backend::url('user/usergroups') ?>"><?= __("User Groups") ?></a></li>
         <li class="breadcrumb-item active"><?= e($this->pageTitle) ?></li>
     </ol>

--- a/controllers/usergroups/index.php
+++ b/controllers/usergroups/index.php
@@ -1,8 +1,1 @@
-<?php Block::put('breadcrumb') ?>
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="<?= Backend::url('user/users') ?>"><?= __("Users") ?></a></li>
-        <li class="breadcrumb-item active" aria-current="page"><?= e($this->pageTitle) ?></li>
-    </ol>
-<?php Block::endPut() ?>
-
 <?= $this->listRender() ?>

--- a/controllers/usergroups/update.php
+++ b/controllers/usergroups/update.php
@@ -1,6 +1,5 @@
 <?php Block::put('breadcrumb') ?>
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="<?= Backend::url('user/users') ?>"><?= __("Users") ?></a></li>
         <li class="breadcrumb-item"><a href="<?= Backend::url('user/usergroups') ?>"><?= __("User Groups") ?></a></li>
         <li class="breadcrumb-item active"><?= e($this->pageTitle) ?></li>
     </ol>

--- a/controllers/users/_list_toolbar.php
+++ b/controllers/users/_list_toolbar.php
@@ -10,14 +10,6 @@
         ->secondary()
         ->confirmMessage("Are you sure?") ?>
 
-    <?php if ($this->user->hasAccess('rainlab.users.access_groups')): ?>
-        <div class="toolbar-divider"></div>
-
-        <?= Ui::button("User Groups", 'user/usergroups')
-            ->icon('icon-group')
-            ->secondary() ?>
-    <?php endif ?>
-
     <?=
         /**
          * @event rainlab.user.view.extendListToolbar

--- a/models/usergroup/fields.yaml
+++ b/models/usergroup/fields.yaml
@@ -5,13 +5,16 @@
 fields:
     name:
         label: Name
+        span: left
+
+    code:
+        label: Code
+        comment: Enter a unique code used to identify this group.
+        preset: name
+        span: right
 
     description:
         label: Description
         type: textarea
         size: small
 
-    code:
-        label: Code
-        comment: Enter a unique code used to identify this group.
-        preset: name


### PR DESCRIPTION
This is a proposal to clarify the navigation of user groups, which more closely corresponds to the navigation of system groups and users.

It moves the link to user group management to the sidebar and modifies the navigation elements of user group pages.

It moves the `code` field in the user group editing form next to the group name for a clearer layout.